### PR TITLE
Add caching of issues

### DIFF
--- a/todo_merger/__init__.py
+++ b/todo_merger/__init__.py
@@ -159,7 +159,7 @@ def create_app(config_file: str):
         app.config["services"][name] = service
 
     # Initiate cache timer
-    app.config["cache_timer"] = None
+    app.config["current_cache_timer"] = None
     app.config["cache_timeout_seconds"] = get_app_config(config_file, "cache").get(
         "timeout_seconds", 600
     )

--- a/todo_merger/__init__.py
+++ b/todo_merger/__init__.py
@@ -82,9 +82,11 @@ def configure_logger(args) -> logging.Logger:
     return log
 
 
-def load_app_config(config_file: str) -> dict[str, tuple[str, Github | Gitlab]]:
+def load_app_services_config(
+    config_file: str, section: str = "services"
+) -> dict[str, tuple[str, Github | Gitlab]]:
     """Load the app config, handle service logins, and return objects"""
-    app_config: dict[str, dict[str, str]] = get_app_config(config_file)
+    app_config: dict[str, dict[str, str]] = get_app_config(config_file, section)
     service_objects: dict[str, tuple[str, Github | Gitlab]] = {}
 
     for name, cfg in app_config.items():
@@ -153,11 +155,14 @@ def create_app(config_file: str):
 
     # Load app config and login to services (e.g. GitHub and GitLab)
     app.config["services"] = {}
-    for name, service in load_app_config(config_file).items():
+    for name, service in load_app_services_config(config_file).items():
         app.config["services"][name] = service
 
     # Initiate cache timer
     app.config["cache_timer"] = None
+    app.config["cache_timeout_seconds"] = get_app_config(config_file, "cache").get(
+        "timeout_seconds", 600
+    )
 
     # blueprint for app
     from .main import main as main_blueprint  # pylint: disable=import-error

--- a/todo_merger/__init__.py
+++ b/todo_merger/__init__.py
@@ -156,6 +156,9 @@ def create_app(config_file: str):
     for name, service in load_app_config(config_file).items():
         app.config["services"][name] = service
 
+    # Initiate cache timer
+    app.config["cache_timer"] = None
+
     # blueprint for app
     from .main import main as main_blueprint  # pylint: disable=import-error
 

--- a/todo_merger/_cache.py
+++ b/todo_merger/_cache.py
@@ -57,7 +57,7 @@ def write_issues_cache(issues: list[IssueItem]) -> None:
         json.dump(issues_cache, jsonfile, indent=2, default=str)
 
 
-def get_cache_status(cache_timer: None | datetime) -> bool:
+def get_cache_status(cache_timer: None | datetime, timeout_seconds: int) -> bool:
     """Find out whether the cache is still valid. Returns False if it must be
     refreshed"""
 
@@ -68,7 +68,7 @@ def get_cache_status(cache_timer: None | datetime) -> bool:
     # Get difference between now and start of cache timer
     cache_diff = datetime.now() - cache_timer
     logging.debug("Current cache time difference: %s", cache_diff)
-    if cache_diff > timedelta(minutes=1):
+    if cache_diff > timedelta(seconds=timeout_seconds):
         logging.info("Cache older than defined. Requesting all issues anew")
         # Mark that cache shall be disregarded
         return False

--- a/todo_merger/_cache.py
+++ b/todo_merger/_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from datetime import datetime, timedelta
 from os.path import join
 
 from platformdirs import user_cache_dir
@@ -54,3 +55,23 @@ def write_issues_cache(issues: list[IssueItem]) -> None:
     logging.debug("Writing issues cache file %s", cache_file)
     with open(cache_file, mode="w", encoding="UTF-8") as jsonfile:
         json.dump(issues_cache, jsonfile, indent=2, default=str)
+
+
+def get_cache_status(cache_timer: None | datetime) -> bool:
+    """Find out whether the cache is still valid. Returns False if it must be
+    refreshed"""
+
+    if cache_timer is None:
+        logging.debug("No cache timer set before")
+        return False
+
+    # Get difference between now and start of cache timer
+    cache_diff = datetime.now() - cache_timer
+    logging.debug("Current cache time difference: %s", cache_diff)
+    if cache_diff > timedelta(minutes=1):
+        logging.info("Cache older than defined. Requesting all issues anew")
+        # Mark that cache shall be disregarded
+        return False
+
+    logging.debug("Cache is still considered to be valid")
+    return True

--- a/todo_merger/_cache.py
+++ b/todo_merger/_cache.py
@@ -62,7 +62,7 @@ def get_cache_status(cache_timer: None | datetime, timeout_seconds: int) -> bool
     refreshed"""
 
     if cache_timer is None:
-        logging.debug("No cache timer set before")
+        logging.debug("No cache timer set before, or manually refreshed")
         return False
 
     # Get difference between now and start of cache timer

--- a/todo_merger/_cache.py
+++ b/todo_merger/_cache.py
@@ -1,0 +1,56 @@
+"""Cache functions"""
+
+import json
+import logging
+from os.path import join
+
+from platformdirs import user_cache_dir
+
+from ._issues import IssueItem
+
+
+def read_issues_cache():
+    """Return the issues cache"""
+    cache_file = join(user_cache_dir("todo-merger", ensure_exists=True), "issues.json")
+
+    logging.debug("Reading issues cache file %s", cache_file)
+    try:
+        with open(cache_file, mode="r", encoding="UTF-8") as jsonfile:
+            list_of_dicts = json.load(jsonfile)
+
+            # Convert to list of IssueItem
+            list_of_dataclasses = []
+            for element in list_of_dicts:
+                list_of_dataclasses.append(IssueItem(**element))
+
+            return list_of_dataclasses
+
+    except json.decoder.JSONDecodeError:
+        logging.error(
+            "Cannot read JSON file %s. Please check its syntax or delete it. "
+            "Will ignore any issues cache.",
+            cache_file,
+        )
+        return {}
+
+    except FileNotFoundError:
+        logging.debug(
+            "Issues cache file '%s' has not been found. Initializing a new empty one.",
+            cache_file,
+        )
+        default_issues_cache: dict = {}
+        write_issues_cache(issues=default_issues_cache)
+
+        return default_issues_cache
+
+
+def write_issues_cache(issues: list[IssueItem]) -> None:
+    """Write issues cache file"""
+
+    cache_file = join(user_cache_dir("todo-merger", ensure_exists=True), "issues.json")
+
+    issues_cache = [issue.convert_to_dict() for issue in issues]
+
+    logging.debug("Writing issues cache file %s", cache_file)
+    with open(cache_file, mode="w", encoding="UTF-8") as jsonfile:
+        json.dump(issues_cache, jsonfile, indent=2, default=str)

--- a/todo_merger/_config.py
+++ b/todo_merger/_config.py
@@ -11,11 +11,14 @@ from platformdirs import user_config_dir
 
 DEFAULT_APP_CONFIG = """# App configuration for ToDo Merger
 
-[github-com]
+[cache]
+timeout_seconds = 600
+
+[services.github-com]
 service = "github"
 token = ""
 
-[gitlab-com]
+[services.gitlab-com]
 service = "gitlab"
 token = ""
 url = "https://gitlab.com"

--- a/todo_merger/_issues.py
+++ b/todo_merger/_issues.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import logging
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
@@ -43,6 +43,10 @@ class IssueItem:  # pylint: disable=too-many-instance-attributes
         are solely derived from attribute values"""
         # updated_at_display
         self.updated_at_display = _time_ago(_convert_to_datetime(self.updated_at))
+
+    def convert_to_dict(self):
+        """Return the current dataclass as dict"""
+        return asdict(self)
 
 
 @dataclass

--- a/todo_merger/_views.py
+++ b/todo_merger/_views.py
@@ -2,8 +2,9 @@
 
 import logging
 
-from todo_merger._config import read_issues_config, write_issues_config
-from todo_merger._issues import (
+from ._cache import read_issues_cache, write_issues_cache
+from ._config import read_issues_config, write_issues_config
+from ._issues import (
     ISSUE_RANKING_TABLE,
     IssueItem,
     IssuesStats,
@@ -14,19 +15,27 @@ from todo_merger._issues import (
 )
 
 
-def view_issues() -> tuple[list[IssueItem], IssuesStats]:
+def get_issues_and_stats(cache: bool) -> tuple[list[IssueItem], IssuesStats]:
     """Functions to view all issues"""
-    config = read_issues_config()
-    issues = get_all_issues()
+    # Get issues (either cache or online)
+    if cache:
+        issues = read_issues_cache()
+    else:
+        issues = get_all_issues()
+        write_issues_cache(issues=issues)
+    # Default prioritization
     issues = prioritize_issues(issues)
+    # Issues custom config (ranking)
+    config = read_issues_config()
     issues = apply_user_issue_ranking(issues=issues, ranking_dict=config)
+    # Stats
     stats = get_issues_stats(issues)
 
     return issues, stats
 
 
 def set_ranking(issue: str, rank: str) -> None:
-    """Set new ranking of issue"""
+    """Set new ranking of individual issue inside of the issues configuration file"""
     rank_int = ISSUE_RANKING_TABLE.get(rank, ISSUE_RANKING_TABLE["normal"])
     config = read_issues_config()
 

--- a/todo_merger/_views.py
+++ b/todo_merger/_views.py
@@ -1,4 +1,4 @@
-"""View functions"""
+"""View functions, removing complexity from main.py"""
 
 import logging
 

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -15,7 +15,10 @@ def index():
     """Index Page"""
 
     # Find out whether current cache timer is still valid
-    cache = get_cache_status(current_app.config["cache_timer"])
+    cache = get_cache_status(
+        cache_timer=current_app.config["cache_timer"],
+        timeout_seconds=current_app.config["cache_timeout_seconds"],
+    )
     # Reset cache timer to now
     if not cache:
         current_app.config["cache_timer"] = datetime.now()

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -16,12 +16,12 @@ def index():
 
     # Find out whether current cache timer is still valid
     cache = get_cache_status(
-        cache_timer=current_app.config["cache_timer"],
+        cache_timer=current_app.config["current_cache_timer"],
         timeout_seconds=current_app.config["cache_timeout_seconds"],
     )
     # Reset cache timer to now
     if not cache:
-        current_app.config["cache_timer"] = datetime.now()
+        current_app.config["current_cache_timer"] = datetime.now()
 
     issues, stats = get_issues_and_stats(cache=cache)
 
@@ -36,5 +36,14 @@ def ranking():
     rank_new = request.args.get("rank", "")
 
     set_ranking(issue=issue, rank=rank_new)
+
+    return redirect("/")
+
+
+@main.route("/reload", methods=["GET"])
+def reload():
+    """Reload all issues and break cache"""
+
+    current_app.config["current_cache_timer"] = None
 
     return redirect("/")

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -2,7 +2,7 @@
 
 from flask import Blueprint, redirect, render_template, request
 
-from ._views import set_ranking, view_issues
+from ._views import get_issues_and_stats, set_ranking
 
 main = Blueprint("main", __name__)
 
@@ -11,7 +11,7 @@ main = Blueprint("main", __name__)
 def index():
     """Index Page"""
 
-    issues, stats = view_issues()
+    issues, stats = get_issues_and_stats(cache=False)
 
     return render_template("index.html", issues=issues, stats=stats)
 

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -1,7 +1,10 @@
 """Main"""
 
-from flask import Blueprint, redirect, render_template, request
+from datetime import datetime
 
+from flask import Blueprint, current_app, redirect, render_template, request
+
+from ._cache import get_cache_status
 from ._views import get_issues_and_stats, set_ranking
 
 main = Blueprint("main", __name__)
@@ -11,7 +14,13 @@ main = Blueprint("main", __name__)
 def index():
     """Index Page"""
 
-    issues, stats = get_issues_and_stats(cache=False)
+    # Find out whether current cache timer is still valid
+    cache = get_cache_status(current_app.config["cache_timer"])
+    # Reset cache timer to now
+    if not cache:
+        current_app.config["cache_timer"] = datetime.now()
+
+    issues, stats = get_issues_and_stats(cache=cache)
 
     return render_template("index.html", issues=issues, stats=stats)
 

--- a/todo_merger/static/sass/custom.scss
+++ b/todo_merger/static/sass/custom.scss
@@ -62,3 +62,7 @@
     }
   }
 }
+
+#refresh-button {
+  padding: 5px 10px;
+}

--- a/todo_merger/templates/index.html
+++ b/todo_merger/templates/index.html
@@ -10,6 +10,12 @@
   {{ stats.total }} items, {{ stats.issues }} issues and {{ stats.pulls }} PRs/MRs.
   {{ stats.gitlab }} from GitLab, {{ stats.github }} from GitHub.
   {{ stats.due_dates_total }} have due dates, {{ stats.milestones_total }} milestones, and {{ stats.epics_total }} epics.
+  <br />
+  <a href="/reload">
+    <button class="secondary" id="refresh-button">
+      <i class="fa-solid fa-rotate-right"></i> Reload all issues
+    </button>
+  </a>
 </p>
 
 {%- for issue in issues|sort(attribute="rank") %}


### PR DESCRIPTION
Fixes #10 

This drastically improves the loading times, especially if we interact with issues.

The default is to make a full refresh every 5 minutes, but that's configurable.

This causes breaking changes with the config file layout! 