### PR TITLE
Mark issue as seen if user ranks them

### DIFF
--- a/todo_merger/_cache.py
+++ b/todo_merger/_cache.py
@@ -111,6 +111,7 @@ def add_to_seen_issues(issues: list[str]) -> None:
 
     # Extend seen issues with new list
     for issue in issues:
+        logging.debug("Marking issue %s as seen", issue)
         seen_issues_cached.append(issue)
 
     # Update file

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -35,7 +35,10 @@ def ranking():
     issue = request.args.get("issue", "")
     rank_new = request.args.get("rank", "")
 
+    # Set ranking
     set_ranking(issue=issue, rank=rank_new)
+    # When ranking an issue, it also makes the issue be marked as seen
+    add_to_seen_issues(issues=[issue])
 
     return redirect("/")
 


### PR DESCRIPTION
Avoids that user has to mark a new issue as seen separately if they want to rank it as well.