### PR TITLE
Collect information about when an issue has been seen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,5 +179,7 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 
+# Local cache, log, build and config files
 config.toml
 *.scss.css*
+*issues*.json

--- a/todo_merger/_views.py
+++ b/todo_merger/_views.py
@@ -4,7 +4,12 @@ import logging
 
 from flask import current_app
 
-from ._cache import get_unseen_issues, read_issues_cache, write_issues_cache
+from ._cache import (
+    get_unseen_issues,
+    read_issues_cache,
+    update_last_seen,
+    write_issues_cache,
+)
 from ._config import read_issues_config, write_issues_config
 from ._issues import (
     ISSUE_RANKING_TABLE,
@@ -33,8 +38,12 @@ def get_issues_and_stats(
     if cache:
         issues = read_issues_cache()
     else:
+        # Get all issues from the services
         issues = get_all_issues()
+        # Update cache file
         write_issues_cache(issues=issues)
+        # Update last_seen flag in seen issues cache
+        update_last_seen()
     # Get previously unseen issues
     new_issues = get_unseen_issues(issues=issues)
     # Default prioritization

--- a/todo_merger/main.py
+++ b/todo_merger/main.py
@@ -59,7 +59,7 @@ def ranking() -> Response:
     # Set ranking
     set_ranking(issue=issue, rank=rank_new)
     # When ranking an issue, it also makes the issue be marked as seen
-    add_to_seen_issues(issues=[issue])
+    add_to_seen_issues(new_unseen_issues=[issue])
 
     return redirect(request.referrer)
 
@@ -74,7 +74,7 @@ def todolist() -> Response:
     # Set ranking
     set_todolist(issue=issue, state=state)
     # When ranking an issue, it also makes the issue be marked as seen
-    add_to_seen_issues(issues=[issue])
+    add_to_seen_issues(new_unseen_issues=[issue])
 
     return redirect(request.referrer)
 
@@ -94,7 +94,7 @@ def mark_as_seen() -> Response:
 
     issues = request.args.get("issues", "").split(",")
 
-    add_to_seen_issues(issues=issues)
+    add_to_seen_issues(new_unseen_issues=issues)
 
     return redirect("/")
 


### PR DESCRIPTION
Makes seen-issues.json cache file a dict to contain first_seen and last_seen dates.

This can later be used to clean config for issues that haven't been seen since a long time, and perhaps also in the seen issues file.

Is breaking, because the cache file is different now. Just delete this seen-issues.json file from your cache and mark all issues as seen again.