### PR TITLE
feat!: restructure command layout, especially for web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ToDo Merger
 
-Get a unified overview of all issues and tasks assigned to you across multiple platforms — in one local web dashboard.
+Get a unified overview of all issues and tasks assigned to you across multiple platforms. A local web dashboard that aggregates GitHub, GitLab, Gitea, and Microsoft Planner into a single view, with personal prioritisation and a private task list. Additionally, a CLI for quick access to your tasks and labels.
 
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 [![License: GPL-3.0-only](https://img.shields.io/badge/license-GPL--3.0--only-blue)](LICENSE.txt)
@@ -16,7 +16,8 @@ Get a unified overview of all issues and tasks assigned to you across multiple p
 - **New issue highlighting** — issues you haven't seen before are highlighted until you dismiss them
 - **Private task creation** — create new issues directly in a configured private repository (GitHub, GitLab, or Gitea) from within the dashboard
 - **Configurable display** — toggle which metadata columns are shown (labels, milestones, epics, assignees, due dates, refs, …)
-- **Daemon mode** — run as a background process with `--daemon` / `stop`
+- **Daemon mode** — run as a background process with `todo-merger web -d` / `todo-merger web stop`
+- **CLI** — quickly list all open tasks as JSON, a compact table, or verbose human-readable output; create new issues and list available labels from the private tasks repo
 - **Fast cache** — configurable cache timeout (default 10 minutes) avoids hammering the APIs on every page load; manual refresh available at any time
 
 
@@ -55,28 +56,38 @@ uv tool install todo-merger  # uv
 
 ## Usage
 
-Please see `todo-merger --help` for the latest usage instructions. In general, the app is started with:
+Please see `todo-merger --help` for the latest usage instructions.
 
 ```sh
-todo-merger [options] [command]
+todo-merger [global options] <command> [command options]
 ```
 
-Open <http://localhost:8636> in your browser after starting.
+**Global options:**
 
-**Important options:**
+| Flag | Description |
+|------|-------------|
+| `-c`, `--config-file` | Path to the config file (default: `~/.config/todo-merger/config.toml`) |
+| `-v` | INFO logging |
+| `-vv` | DEBUG logging |
+| `-vvv` | DEBUG logging including verbose HTTP client logs |
+| `--version` | Show version and exit |
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-c`, `--config-file` | Path to the config file | `~/.config/todo-merger/config.toml` |
-| `-d`, `--daemon` | Run in the background, logging to a file | — |
-| `-v` | INFO logging | — |
-| `-vv` | DEBUG logging | — |
-
-**Important Commands:**
+**Commands:**
 
 | Command | Description |
 |---------|-------------|
-| `stop` | Stop a running background instance |
+| `web` | Start the web interface (open <http://localhost:8636>) |
+| `web -d` | Start in daemon (background) mode |
+| `web stop` | Stop a running background instance |
+| `web --port PORT` | Use a custom port |
+| `list` | List all open tasks as JSON |
+| `list --table` | Compact table view (rank, title, clickable link) |
+| `list --plain` | Verbose human-readable output |
+| `list --cache` | Use cached data without fetching from APIs |
+| `labels` | List available labels from the private tasks repo |
+| `create TITLE` | Create a new issue in the private tasks repo |
+| `create TITLE --rank pin` | Create and immediately rank the issue |
+| `create TITLE --label bug` | Create with a label (repeatable) |
 
 
 ## Configuration

--- a/todo_merger/__init__.py
+++ b/todo_merger/__init__.py
@@ -39,24 +39,11 @@ __version__ = version("todo-merger")
 parser = argparse.ArgumentParser(
     description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
-subparsers = parser.add_subparsers(dest="command", help="Special commands")
+subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
 parser.add_argument(
     "-c", "--config-file", help="Path to the app config file ", default=default_config_file_path()
 )
-parser.add_argument(
-    "-d",
-    "--daemon",
-    help="Start the app in the background and log to a file",
-    action="store_true",
-)
-parser.add_argument(
-    "-l", "--logfile", help="Path to the log file (in daemon mode)", default=LOGFILE
-)
-parser.add_argument(
-    "-p", "--pidfile", help="Path to the PID file (in daemon mode)", default=PIDFILE
-)
-parser.add_argument("--port", help="Port the application runs on", type=int, default=8636)
 parser.add_argument(
     "-v",
     "--verbose",
@@ -77,11 +64,29 @@ parser.add_argument(
 )
 parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
 
-# Special commands
-parser_stop = subparsers.add_parser(
-    "stop",
-    help="Stop the running todo-merger background instance",
+# web subcommand (start/stop the web interface)
+parser_web = subparsers.add_parser(
+    "web",
+    help="Start the web interface",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
+parser_web.add_argument(
+    "-d",
+    "--daemon",
+    help="Start the app in the background and log to a file",
+    action="store_true",
+)
+parser_web.add_argument(
+    "-l", "--logfile", help="Path to the log file (in daemon mode)", default=LOGFILE
+)
+parser_web.add_argument(
+    "-p", "--pidfile", help="Path to the PID file (in daemon mode)", default=PIDFILE
+)
+parser_web.add_argument("--port", help="Port the application runs on", type=int, default=8636)
+web_subparsers = parser_web.add_subparsers(dest="web_command")
+web_subparsers.add_parser("stop", help="Stop the running background instance")
+
+# list subcommand
 parser_list = subparsers.add_parser(
     "list",
     help="List all open tasks with full metadata and exit",
@@ -102,11 +107,13 @@ parser_list.add_argument(
     action="store_true",
 )
 
-parser_list_labels = subparsers.add_parser(
-    "list-labels",
+# labels subcommand
+parser_labels = subparsers.add_parser(
+    "labels",
     help="List available labels from the private tasks repository",
 )
 
+# create subcommand
 parser_create = subparsers.add_parser(
     "create",
     help="Create a new issue in the private tasks repository",
@@ -450,21 +457,12 @@ def main() -> None:
     # Configure logger
     logger = configure_logger(args=args)
 
-    # Stop app if requested
-    if args.command == "stop":
-        try:
-            with open(args.pidfile, encoding="utf-8") as pidreader:
-                pid = int(pidreader.read())
-                print(f"Sending SIGTERM to process {pid}")
-                kill(pid, signal.SIGTERM)
-                sys.exit()
-        except FileNotFoundError:
-            sys.exit(
-                f"PID file {args.pidfile} does not seem to exist. The app does not seem to run "
-                "normally or at all. Check your task manager and process list."
-            )
+    # Show help if no command given
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
 
-    # List issues if requested
+    # List issues
     if args.command == "list":
         cli_list_issues(
             config_file=args.config_file,
@@ -474,12 +472,12 @@ def main() -> None:
         )
         sys.exit()
 
-    # List labels if requested
-    if args.command == "list-labels":
+    # List labels
+    if args.command == "labels":
         cli_list_labels(config_file=args.config_file)
         sys.exit()
 
-    # Create issue if requested
+    # Create issue
     if args.command == "create":
         cli_create_issue(
             config_file=args.config_file,
@@ -489,21 +487,39 @@ def main() -> None:
         )
         sys.exit()
 
-    # Start app
-    print(f"ToDo Merger will be available on http://localhost:{args.port}")
-    logging.info("Config file: %s", args.config_file)
-    logging.info("Log file: %s", args.logfile)
-    logging.info("PID file: %s", args.pidfile)
-    if args.daemon:
-        if daemon is None:
-            sys.exit(
-                "Daemonizing this app is not possible on your system, e.g. because it's Windows."
-            )
-        with daemon.DaemonContext(pidfile=daemon.pidfile.TimeoutPIDLockFile(args.pidfile)):
-            # Add file logger
-            logger.addHandler(logging.FileHandler(args.logfile))
+    # Web interface
+    if args.command == "web":
+        # Stop daemon
+        if args.web_command == "stop":
+            try:
+                with open(args.pidfile, encoding="utf-8") as pidreader:
+                    pid = int(pidreader.read())
+                    print(f"Sending SIGTERM to process {pid}")
+                    kill(pid, signal.SIGTERM)
+                    sys.exit()
+            except FileNotFoundError:
+                sys.exit(
+                    f"PID file {args.pidfile} does not seem to exist. "
+                    "The app does not seem to run normally or at all. "
+                    "Check your task manager and process list."
+                )
 
-            # Run server
+        # Start server
+        print(f"ToDo Merger will be available on http://localhost:{args.port}")
+        logging.info("Config file: %s", args.config_file)
+        logging.info("Log file: %s", args.logfile)
+        logging.info("PID file: %s", args.pidfile)
+        if args.daemon:
+            if daemon is None:
+                sys.exit(
+                    "Daemonizing this app is not possible on your system, "
+                    "e.g. because it's Windows."
+                )
+            with daemon.DaemonContext(pidfile=daemon.pidfile.TimeoutPIDLockFile(args.pidfile)):
+                # Add file logger
+                logger.addHandler(logging.FileHandler(args.logfile))
+
+                # Run server
+                run_server(config_file=args.config_file, port=args.port)
+        else:
             run_server(config_file=args.config_file, port=args.port)
-    else:
-        run_server(config_file=args.config_file, port=args.port)


### PR DESCRIPTION
BREAKING: `todo-merger` does not launch the web interface as before. This has been moved to `todo-merger web`, alongside with the parameters like `--port` or the `stop` subcommand.

Ensures that it's clear which flags and subcommands belong to the web dashboard.